### PR TITLE
chore: update commitlint configuration to allow unlimited footer line length

### DIFF
--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -2,5 +2,6 @@ export default {
     extends: ['@commitlint/config-conventional'],
     rules: {
         'body-max-line-length': [0, 'never'],
+        'footer-max-line-length': [0, 'never'],
     },
 };


### PR DESCRIPTION
This pull request makes a minor update to the commit linting rules by disabling the maximum line length check for commit footers. This change ensures that commit footers can be any length without causing linting errors.

* Commit linting configuration: Disabled the `footer-max-line-length` rule in `commitlint.config.mjs` to allow unlimited line length for commit footers.