### PR TITLE
docs: update CONTRIBUTING.md and README.md for clarity and consistency

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,14 +96,20 @@ Each commit message consists of a **header**, a **body**, and a **footer**. The 
 
 The type must be one of the following:
 
-- **feat**: A new feature
-- **fix**: A bug fix
-- **docs**: Documentation only changes
-- **style**: Changes that do not affect the meaning of the code (white-space, formatting, etc)
-- **refactor**: A code change that neither fixes a bug nor adds a feature
-- **perf**: A code change that improves performance
-- **test**: Adding missing tests or correcting existing tests
-- **chore**: Changes to the build process or auxiliary tools and libraries
+- **feat**: A new feature (triggers a MINOR version increment)
+- **fix**: A bug fix (triggers a PATCH version increment)
+- **docs**: Documentation only changes (no version increment)
+- **style**: Changes that do not affect the meaning of the code (white-space, formatting, etc) (no version increment)
+- **refactor**: A code change that neither fixes a bug nor adds a feature (no version increment)
+- **perf**: A code change that improves performance (triggers a PATCH version increment)
+- **test**: Adding missing tests or correcting existing tests (no version increment)
+- **chore**: Changes to the build process or auxiliary tools and libraries (no version increment)
+
+#### Version Increments
+
+- **MAJOR**: Incremented when there are breaking changes (indicated by "BREAKING CHANGE:" in the commit footer)
+- **MINOR**: Incremented when new features are added (feat type)
+- **PATCH**: Incremented when bugs are fixed (fix type) or performance is improved (perf type)
 
 #### Examples
 
@@ -229,6 +235,8 @@ jobs:
           target-dev-hub: ${{ env.TARGET_DEV_HUB }}
           installation-key-bypass: true
           code-coverage: true
+          timeout: 90
+          polling-interval: 30
 
       # Use the action outputs
       - name: Show package details

--- a/README.md
+++ b/README.md
@@ -29,20 +29,16 @@ Creating and managing Salesforce 2GP packages can be time-consuming and error-pr
 | Name | Description | Required | Default |
 |------|-------------|----------|---------|
 | `auth-url` | The URL of the Dev Hub org. This is used to create an auth file for the Dev Hub org. | Yes | |
-| `packaging-directory` | The directory containing the Salesforce project. | No | `./` |
-| `package` | ID (starts with 0Ho) or alias of the package to create a version of. | Yes | |
+| `package` | Alias of the package to create a version of. | Yes | |
 | `target-dev-hub` | Username or alias of the Dev Hub org. | Yes | |
-| `installation-key-bypass` | Bypass the installation key requirement. If you bypass this requirement, anyone can install your package. | No | |
-| `installation-key` | Installation key for the package version. Omit this flag if you specify `installation-key-bypass`. | No | |
-| `skip-validation` | Skip validation during package version creation; you can't promote unvalidated package versions. | No | |
-| `code-coverage` | Calculate and store the code coverage percentage by running the packaged Apex tests. | No | |
+| `packaging-directory` | The directory containing the Salesforce project. If not specified, the action will run in the same directory as the action. | No | |
+| `installation-key-bypass` | Bypass the installation key requirement. (either --installation-key or --installation-key-bypass is required). If you bypass this requirement, anyone can install your package. | No | |
+| `installation-key` | Installation key for the package version. The default is null. Omit this flag if you specify --installation-key-bypass. | No | |
+| `skip-validation` | Skip validation during package version creation; you can't promote unvalidated package versions. Skips validation of dependencies, package ancestors, and metadata during package version creation. | No | |
+| `code-coverage` | Calculate and store the code coverage percentage by running the packaged Apex tests included in this package version. | No | |
 | `async-validation` | Return a new package version before completing package validations. | No | |
-| `path` | Path to directory that contains the contents of the package. | No | |
-| `version-name` | Name of the package version to be created. | No | |
-| `version-description` | Description of the package version to be created. | No | |
-| `version-number` | Version number in the format major.minor.patch.build. | No | |
-| `timeout` | Maximum time in minutes to wait for package creation to complete. | No | 60 |
-| `polling-interval` | Time in seconds between status check attempts. | No | 60 |
+| `timeout` | Maximum time in minutes to wait for package creation to complete. Default is 60 minutes (1 hour). | No | 60 |
+| `polling-interval` | Time in seconds between status check attempts. Default is 60 seconds (1 minute). | No | 60 |
 
 ## 📤 Outputs
 
@@ -86,7 +82,7 @@ jobs:
           cache: 'npm'
 
       - name: Create package version
-        uses: mathias-moreira/salesforce-ci-packager
+        uses: mathias-moreira/salesforce-ci-packager@v2
         id: create-package-version
         with:
           auth-url: ${{ secrets.AUTH_URL }}
@@ -105,6 +101,8 @@ jobs:
 
 This action uses the following Salesforce CLI commands:
 
+- `sf package create`: Creates a new package
+- `sf package list`: Lists all packages in the Dev Hub org
 - `sf package version create`: Creates a new package version
 - `sf package version create report`: Checks the status of a package version creation request
 
@@ -129,6 +127,3 @@ This project is licensed under the MIT License - see the LICENSE file for detail
 💡 **Tip:** Store your `auth-url` as a GitHub secret to keep your credentials secure!
 
 ⭐ If you find this action helpful, consider giving it a star on GitHub!
-
----
-This is a test. Used to test branch protection rules and workflows.


### PR DESCRIPTION
This pull request updates documentation to clarify usage, improve accuracy, and provide more detail on versioning and configuration. The most important changes are grouped below.

**Commit Message Guidelines and Versioning:**

* Expanded the commit type descriptions in `CONTRIBUTING.md` to specify which types trigger version increments (MAJOR, MINOR, PATCH), and added a new section explaining how version increments are determined based on commit types and footers.

**Action Input/Output Documentation:**

* Improved the input table in `README.md` by clarifying descriptions, adjusting default values, and specifying requirements for fields like `package`, `packaging-directory`, `installation-key`, and `installation-key-bypass`.
* Updated the usage example in `README.md` to reference the correct action version (`@v2`).
* Added missing Salesforce CLI commands (`sf package create`, `sf package list`) to the list of commands used by the action in `README.md`.

**Configuration Improvements:**

* Added `timeout` and `polling-interval` parameters to the workflow configuration in `CONTRIBUTING.md` to allow for more control over package creation timing.

**General Cleanup:**

* Removed test and placeholder text from the end of `README.md` for a cleaner presentation.