### PR TITLE
chore: remove push trigger from PR validation workflow

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -4,8 +4,6 @@ on:
   pull_request:
     branches: [master]
     types: [opened, synchronize, reopened, edited]
-  push:
-    branches: [master]
 
 permissions:
   contents: read


### PR DESCRIPTION
This pull request makes a small update to the GitHub Actions workflow configuration by removing the workflow trigger for pushes to the `master` branch. Now, the workflow will only run on pull request events.

* [`.github/workflows/pr-validation.yml`](diffhunk://#diff-04af3c9c96028eebf4fa93d5c67e1fa08255fb7a3682f912ccd5bea1dff5ccd4L7-L8): Removed the `push` event trigger for the `master` branch, so the workflow only runs on pull request events.