### PR TITLE
feat(runtime): upgrade action to Node.js 24

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -5,7 +5,7 @@ branding:
   color: blue
 author: Mathias Moreira
 runs:
-  using: node20
+  using: node24
   main: dist/index.js
  
 inputs:


### PR DESCRIPTION
**BREAKING CHANGE**: Requires Actions Runner v2.327.1 or later. GitHub-hosted runners already meet this requirement. Self-hosted runners may need updating.

  ## Node.js 24 Runtime Upgrade

  Updates the action runtime from Node.js 20 to Node.js 24 ahead of GitHub's June 2, 2026 deprecation deadline. After which all actions will be forced to run on Node.js 24.

  Reference: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

  ### Changes

  - `action.yml`: `using: node20` → `using: node24`
  